### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # one lyne
 Random Python one-liners
+
+[![Run on Repl.it](https://repl.it/badge/github/jlsajfj/one-lyne)](https://repl.it/github/jlsajfj/one-lyne)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@jlsajfj/one-lyne).